### PR TITLE
Fix CI and setuptools-betterproto configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,7 +293,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
+          python -m pip install -e .[dev-mkdocs]
           python -m pip freeze
 
       - name: Generate the documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,10 +88,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox
@@ -202,10 +206,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,7 +294,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install .[dev-mkdocs]
-          pip freeze
+          python -m pip freeze
 
       - name: Generate the documentation
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -118,7 +118,7 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -214,7 +214,7 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -271,7 +271,7 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -313,7 +313,7 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,4 +13,4 @@ recursive-exclude tests *
 recursive-include frequenz-api-microgrid/proto *.proto
 recursive-include frequenz-api-microgrid/submodules/frequenz-api-common/proto *.proto
 recursive-include frequenz-api-microgrid/submodules/api-common-protos *.proto
-recursive-include py *.pyi
+recursive-include src *.pyi

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Introduction
 
-Bindings to the microgrid API generated using betterproto
+Bindings to the [microgrid API] generated using [betterproto].
 
-TODO(cookiecutter): Improve the README file
+Versions of this package matches the version of the API it is generated from.
 
 ## Supported Platforms
 
@@ -22,3 +22,6 @@ The following platforms are officially supported (tested):
 
 If you want to know how to build this project and contribute to it, please
 check out the [Contributing Guide](CONTRIBUTING.md).
+
+[betterproto]: https://test-betterproto.readthedocs.io/en/docs/index.html
+[microgrid API]: https://frequenz-floss.github.io/frequenz-api-microgrid/

--- a/docs/_scripts/macros.py
+++ b/docs/_scripts/macros.py
@@ -27,10 +27,7 @@ def _slugify(text: str) -> str:
     Returns:
         The slugified text.
     """
-    # The type of the return value is not defined for the markdown library.
-    # Also for some reason `mypy` thinks the `toc` module doesn't have a
-    # `slugify_unicode` function, but it definitely does.
-    return toc.slugify_unicode(text, "-")  # type: ignore[attr-defined,no-any-return]
+    return toc.slugify_unicode(text, "-")
 
 
 def _hook_macros_plugin(env: macros.MacrosPlugin) -> None:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: "Copyright © 2024 Frequenz Energy-as-a-Service GmbH"
 repo_name: "frequenz-microgrid-betterproto"
 repo_url: "https://github.com/frequenz-floss/frequenz-microgrid-betterproto-python"
 edit_uri: "edit/v0.x.x/docs/"
-strict: true  # Treat warnings as errors
+strict: false  # Some stuff coming from betterproto/google has warnings
 
 # Build directories
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
-      alias_type: redirect
+      alias_type: symlink
       canonical_version: latest
   - mkdocstrings:
       default_handler: python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # See https://mkdocstrings.github.io/python/usage/#import for details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.4",
   "mkdocs-material == 9.3.1",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.24.2",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[lib] == 0.9.2",
 ]
 dev-mypy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev-flake8 = [
 dev-formatting = ["black == 23.9.1", "isort == 5.12.0"]
 dev-mkdocs = [
   "black == 23.9.1",
-  "Markdown==3.4.4",
+  "Markdown == 3.6",
   "mike == 2.0.0",
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.1",
@@ -67,7 +67,7 @@ dev-mkdocs = [
 ]
 dev-mypy = [
   "mypy == 1.5.1",
-  "types-Markdown == 3.4.2.10",
+  "types-Markdown == 3.6.0.20240316",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-microgrid-betterproto[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ version_scheme = "post-release"
 
 [tool.setuptools_betterproto]
 proto_path = "frequenz-api-microgrid/proto"
-out_dir = "src/frequenz/microgrid/betterproto"
+out_path = "src/frequenz/microgrid/betterproto"
 include_paths = [
   "frequenz-api-microgrid/submodules/api-common-protos",
   "frequenz-api-microgrid/submodules/frequenz-api-common/proto",


### PR DESCRIPTION
We need this to fetch the dependencies of the frequenz-api-microgrid submodule and to generate the python files in the correct path. It also fixes some other small issues with the CI and make some fixes and improvements to the docs generation.