### PR TITLE
ci: Install the package in editable mode when publishing docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -335,7 +335,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install .[dev-mkdocs]
+          python -m pip install -e .[dev-mkdocs]
           pip freeze
 
       - name: Calculate and check version


### PR DESCRIPTION
The docs need access to src/, so we need to make sure the generated files are present in the source tree.
